### PR TITLE
Update subgrounds version and fix RFV and Mkt. Value per OHM charts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ requests = "*"
 retrying = "*"
 pycoingecko = "*"
 dash-extensions = "*"
-subgrounds = "*"
+subgrounds = "==0.0.3"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eb5399b950c134784753d203544b6ef06f7af4d6534b3471e6955a883c3c0d20"
+            "sha256": "da83cd3ff09461ccd91485365d6951b0b5e475a0bceb436d52c044aca5c709d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,6 +26,7 @@
         },
         "brotli": {
             "hashes": [
+                "sha256:12effe280b8ebfd389022aa65114e30407540ccb89b177d3fbc9a4f177c4bd5d",
                 "sha256:160c78292e98d21e73a4cc7f76a234390e516afcd982fa17e1422f7c6a9ce9c8",
                 "sha256:16d528a45c2e1909c2798f27f7bf0a3feec1dc9e50948e738b961618e38b6a7b",
                 "sha256:19598ecddd8a212aedb1ffa15763dd52a388518c4550e615aed88dc3753c0f0c",
@@ -35,10 +36,13 @@
                 "sha256:26d168aac4aaec9a4394221240e8a5436b5634adc3cd1cdf637f6645cecbf181",
                 "sha256:29d1d350178e5225397e28ea1b7aca3648fcbab546d20e7475805437bfb0a130",
                 "sha256:2aad0e0baa04517741c9bb5b07586c642302e5fb3e75319cb62087bd0995ab19",
+                "sha256:3496fc835370da351d37cada4cf744039616a6db7d13c430035e901443a34daa",
                 "sha256:35a3edbe18e876e596553c4007a087f8bcfd538f19bc116917b3c7522fca0429",
                 "sha256:3b78a24b5fd13c03ee2b7b86290ed20efdc95da75a3557cc06811764d5ad1126",
                 "sha256:40d15c79f42e0a2c72892bf407979febd9cf91f36f495ffb333d1d04cebb34e4",
                 "sha256:44bb8ff420c1d19d91d79d8c3574b8954288bdff0273bf788954064d260d7ab0",
+                "sha256:4688c1e42968ba52e57d8670ad2306fe92e0169c6f3af0089be75bbac0c64a3b",
+                "sha256:495ba7e49c2db22b046a53b469bbecea802efce200dffb69b93dd47397edc9b6",
                 "sha256:4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438",
                 "sha256:503fa6af7da9f4b5780bb7e4cbe0c639b010f12be85d02c99452825dd0feef3f",
                 "sha256:56d027eace784738457437df7331965473f2c0da2c70e1a1f6fdbae5402e0389",
@@ -50,10 +54,13 @@
                 "sha256:68715970f16b6e92c574c30747c95cf8cf62804569647386ff032195dc89a430",
                 "sha256:6b2ae9f5f67f89aade1fab0f7fd8f2832501311c363a21579d02defa844d9296",
                 "sha256:6c772d6c0a79ac0f414a9f8947cc407e119b8598de7621f39cacadae3cf57d12",
+                "sha256:6d847b14f7ea89f6ad3c9e3901d1bc4835f6b390a9c71df999b0162d9bb1e20f",
                 "sha256:76ffebb907bec09ff511bb3acc077695e2c32bc2142819491579a695f77ffd4d",
+                "sha256:7bbff90b63328013e1e8cb50650ae0b9bac54ffb4be6104378490193cd60f85a",
                 "sha256:7cb81373984cc0e4682f31bc3d6be9026006d96eecd07ea49aafb06897746452",
                 "sha256:7ee83d3e3a024a9618e5be64648d6d11c37047ac48adff25f12fa4226cf23d1c",
                 "sha256:854c33dad5ba0fbd6ab69185fec8dab89e13cda6b7d191ba111987df74f38761",
+                "sha256:85f7912459c67eaab2fb854ed2bc1cc25772b300545fe7ed2dc03954da638649",
                 "sha256:87fdccbb6bb589095f413b1e05734ba492c962b4a45a13ff3408fa44ffe6479b",
                 "sha256:88c63a1b55f352b02c6ffd24b15ead9fc0e8bf781dbe070213039324922a2eea",
                 "sha256:8a674ac10e0a87b683f4fa2b6fa41090edfd686a6524bd8dedbd6138b309175c",
@@ -63,15 +70,23 @@
                 "sha256:97f715cf371b16ac88b8c19da00029804e20e25f30d80203417255d239f228b5",
                 "sha256:9bf919756d25e4114ace16a8ce91eb340eb57a08e2c6950c3cebcbe3dff2a5e7",
                 "sha256:9d12cf2851759b8de8ca5fde36a59c08210a97ffca0eb94c532ce7b17c6a3d1d",
+                "sha256:9ed4c92a0665002ff8ea852353aeb60d9141eb04109e88928026d3c8a9e5433c",
                 "sha256:a72661af47119a80d82fa583b554095308d6a4c356b2a554fdc2799bc19f2a43",
                 "sha256:afde17ae04d90fbe53afb628f7f2d4ca022797aa093e809de5c3cf276f61bbfa",
+                "sha256:b336c5e9cf03c7be40c47b5fd694c43c9f1358a80ba384a21969e0b4e66a9b17",
                 "sha256:b663f1e02de5d0573610756398e44c130add0eb9a3fc912a09665332942a2efb",
+                "sha256:b83bb06a0192cccf1eb8d0a28672a1b79c74c3a8a5f2619625aeb6f28b3a82bb",
                 "sha256:c2415d9d082152460f2bd4e382a1e85aed233abc92db5a3880da2257dc7daf7b",
                 "sha256:c83aa123d56f2e060644427a882a36b3c12db93727ad7a7b9efd7d7f3e9cc2c4",
                 "sha256:cfc391f4429ee0a9370aa93d812a52e1fee0f37a81861f4fdd1f4fb28e8547c3",
                 "sha256:db844eb158a87ccab83e868a762ea8024ae27337fc7ddcbfcddd157f841fdfe7",
                 "sha256:defed7ea5f218a9f2336301e6fd379f55c655bea65ba2476346340a0ce6f74a1",
                 "sha256:e16eb9541f3dd1a3e92b89005e37b1257b157b7256df0e36bd7b33b50be73bcb",
+                "sha256:e23281b9a08ec338469268f98f194658abfb13658ee98e2b7f85ee9dd06caa91",
+                "sha256:e2d9e1cbc1b25e22000328702b014227737756f4b5bf5c485ac1d8091ada078b",
+                "sha256:e48f4234f2469ed012a98f4b7874e7f7e173c167bed4934912a29e03167cf6b1",
+                "sha256:e4c4e92c14a57c9bd4cb4be678c25369bf7a092d55fd0866f759e425b9660806",
+                "sha256:ec1947eabbaf8e0531e8e899fc1d9876c179fc518989461f5d24e2223395a9e3",
                 "sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1"
             ],
             "version": "==1.0.9"
@@ -392,7 +407,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pytz": {
@@ -430,16 +445,16 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "subgrounds": {
             "hashes": [
-                "sha256:5a5aed6be804fb84db8f4578e58886600a316d5a4fdc860ae2f31279b2aa4da3",
-                "sha256:e1fd0416c07581252a9e4b6bf02b65f91eb91ba72e57e971f6051a019549f8a5"
+                "sha256:80904d9cf3112273e3f116e966f6d2bccb55f71e0d17d27d6f7ada69b67f973b",
+                "sha256:c319005b9062ae4de4bca403f5dccf00ece79182d129b57cc6d322be4ba7fde0"
             ],
             "index": "pypi",
-            "version": "==0.0.2"
+            "version": "==0.0.3"
         },
         "tenacity": {
             "hashes": [

--- a/apps/Playgrounds_analytics_proto_1.py
+++ b/apps/Playgrounds_analytics_proto_1.py
@@ -19,7 +19,7 @@ from millify import millify
 from subgrounds.dash_wrappers import Graph
 from subgrounds.plotly_wrappers import Figure, Scatter, Indicator
 
-from olympus_subgrounds import protocol_metrics_1year, last_metric, sg, immediate
+from olympus_subgrounds import sg, protocol_metrics_1year, last_metric, proposals, immediate
 
 # This is a single page app
 
@@ -620,6 +620,55 @@ app.layout = dbc.Container([
             ], style={'height': '100%'}, color='#273342', inverse=True),
         ], xs=12, sm=12, md=12, lg=6, xl=6),
     ], style={'padding': '10px'}),
+    html.Div([
+        Graph(Figure(
+            subgrounds=sg,
+            traces=[
+            Scatter(
+                x=proposals.datetime,
+                y=proposals.votes,
+                text=proposals.summary,
+                name='proposals',
+                mode='markers',
+            ),
+            Scatter(
+                x=protocol_metrics_1year.datetime,
+                y=protocol_metrics_1year.treasuryMarketValue,
+                name='treasury_market_value',
+                yaxis='y2',
+            )
+            ],
+            layout={
+            'showlegend': True,
+            'hovermode': 'x',
+            'spikedistance': -1,
+            'xaxis': {
+                'showspikes': True,
+                'spikedash': 'solid',
+                'spikemode': 'across+toaxis',
+                'spikesnap': 'cursor',
+                'spikecolor': 'black',
+                'spikethickness': 1,
+                'showline': True,
+                'showgrid': True
+            },
+            'yaxis': {
+                'title': 'Proposals',
+                'titlefont': {'color': '#1f77b4'},
+                'tickfont': {'color': '#ffffff'},
+            },
+            'yaxis2': {
+                'title': 'Treasury Market Value',
+                'titlefont': {'color': '#ff7f0e'},
+                'tickfont': {'color': '#ff7f0e'},
+                'anchor': 'free',
+                'overlaying': 'y',
+                'side': 'left',
+                'position': 0.05,
+            },
+            }
+        ))
+    ]),
     html.Footer('Powered by Protean Labs',
                 style={'backgrounds-color': '#2e343e',
                        'color': 'white',

--- a/apps/Playgrounds_analytics_proto_1.py
+++ b/apps/Playgrounds_analytics_proto_1.py
@@ -19,7 +19,7 @@ from millify import millify
 from subgrounds.dash_wrappers import Graph
 from subgrounds.plotly_wrappers import Figure, Scatter, Indicator
 
-from olympus_subgrounds import protocol_metrics_1year, last_metric, sg
+from olympus_subgrounds import protocol_metrics_1year, last_metric, sg, immediate
 
 # This is a single page app
 
@@ -143,11 +143,8 @@ app.layout = dbc.Container([
                     html.Hr(className='my-2'),
                     html.H1('$' +
                             millify(
-                                sg.execute(
-                                    sg.mk_request([
-                                        last_metric.marketCap
-                                    ])
-                                )[0]['protocolMetrics'][0]['marketCap'],
+                                immediate(sg, last_metric.marketCap),
+                                # last_metric.marketCap.extract_data(sg.execute(sg.mk_request([last_metric.marketCap]))),
                                 precision=2),
                             style={'text-align': 'center'}
                             ),
@@ -161,11 +158,12 @@ app.layout = dbc.Container([
                     html.Hr(className='my-2'),
                     html.H1('$' +
                             millify(
-                                sg.execute(
-                                    sg.mk_request([
-                                        last_metric.ohmPrice
-                                    ])
-                                )[0]['protocolMetrics'][0]['ohmPrice'],
+                                immediate(sg, last_metric.ohmPrice),
+                                # sg.execute(
+                                #     sg.mk_request([
+                                #         last_metric.ohmPrice
+                                #     ])
+                                # )[0]['protocolMetrics'][0]['ohmPrice'],
                                 precision=2),
                             style={'text-align': 'center'}
                             ),
@@ -179,11 +177,12 @@ app.layout = dbc.Container([
                     html.Hr(className='my-2'),
                     html.H1(
                         millify(
-                            sg.execute(
-                                sg.mk_request([
-                                    last_metric.currentAPY
-                                ])
-                            )[0]['protocolMetrics'][0]['currentAPY'],
+                            immediate(sg, last_metric.currentAPY),
+                            # sg.execute(
+                            #     sg.mk_request([
+                            #         last_metric.currentAPY
+                            #     ])
+                            # )[0]['protocolMetrics'][0]['currentAPY'],
                             precision=2),
                         style={'text-align': 'center'}
                     ),
@@ -197,11 +196,12 @@ app.layout = dbc.Container([
                     html.Hr(className='my-2'),
                     html.H1(
                         millify(
-                            sg.execute(
-                                sg.mk_request([
-                                    last_metric.totalValueLocked
-                                ])
-                            )[0]['protocolMetrics'][0]['totalValueLocked'],
+                            immediate(sg, last_metric.totalValueLocked),
+                            # sg.execute(
+                            #     sg.mk_request([
+                            #         last_metric.totalValueLocked
+                            #     ])
+                            # )[0]['protocolMetrics'][0]['totalValueLocked'],
                             precision=2),
                         style={'text-align': 'center'}
                     ),
@@ -218,11 +218,12 @@ app.layout = dbc.Container([
                     ]),
                     dbc.Col([
                         millify(
-                            sg.execute(
-                                sg.mk_request([
-                                    last_metric.treasuryRiskFreeValue
-                                ])
-                            )[0]['protocolMetrics'][0]['treasuryRiskFreeValue'],
+                            immediate(sg, last_metric.treasuryRiskFreeValue),
+                            # sg.execute(
+                            #     sg.mk_request([
+                            #         last_metric.treasuryRiskFreeValue
+                            #     ])
+                            # )[0]['protocolMetrics'][0]['treasuryRiskFreeValue'],
                             precision=2)
                     ]),
                 ]),
@@ -281,11 +282,12 @@ app.layout = dbc.Container([
                     ]),
                     dbc.Col([
                         millify(
-                            sg.execute(
-                                sg.mk_request([
-                                    last_metric.treasuryMarketValue
-                                ])
-                            )[0]['protocolMetrics'][0]['treasuryMarketValue'],
+                            immediate(sg, last_metric.treasuryMarketValue),
+                            # sg.execute(
+                            #     sg.mk_request([
+                            #         last_metric.treasuryMarketValue
+                            #     ])
+                            # )[0]['protocolMetrics'][0]['treasuryMarketValue'],
                             precision=2)
                     ]),
                 ]),
@@ -371,11 +373,12 @@ app.layout = dbc.Container([
                         ]),
                         dbc.Col([
                             millify(
-                                sg.execute(
-                                    sg.mk_request([
-                                        protocol_metrics_1year.marketCap
-                                    ])
-                                )[0]['protocolMetrics'][0]['marketCap'],
+                                immediate(sg, last_metric.marketCap),
+                                # sg.execute(
+                                #     sg.mk_request([
+                                #         protocol_metrics_1year.marketCap
+                                #     ])
+                                # )[0]['protocolMetrics'][0]['marketCap'],
                                 precision=2)
                         ]),
                     ]),

--- a/apps/olympus_subgrounds.py
+++ b/apps/olympus_subgrounds.py
@@ -6,28 +6,52 @@ from dash import html
 from subgrounds.dash_wrappers import Graph
 from subgrounds.plotly_wrappers import Figure, Scatter, Indicator
 from subgrounds.schema import TypeRef
-from subgrounds.subgraph import SyntheticField
+from subgrounds.subgraph import SyntheticField, FieldPath
 from subgrounds.subgrounds import Subgrounds
 
 
 sg = Subgrounds()
 olympusDAO = sg.load_subgraph('https://api.thegraph.com/subgraphs/name/drondin/olympus-protocol-metrics')
 
+def immediate(sg: Subgrounds, fpath: FieldPath):
+  data = sg.execute(sg.mk_request([fpath]))
+  return fpath.extract_data(data)[0]
+
 # Define useful synthetic fields
 olympusDAO.ProtocolMetric.datetime = SyntheticField(
   lambda timestamp: str(datetime.fromtimestamp(timestamp)),
-  TypeRef.Named('String'),
+  SyntheticField.STRING,
   olympusDAO.ProtocolMetric.timestamp,
 )
 
-olympusDAO.ProtocolMetric.staked_supply_percent = 100 * olympusDAO.ProtocolMetric.sOhmCirculatingSupply / (1 + olympusDAO.ProtocolMetric.totalSupply)
+# olympusDAO.ProtocolMetric.staked_supply_percent = 100 * olympusDAO.ProtocolMetric.sOhmCirculatingSupply / olympusDAO.ProtocolMetric.totalSupply
+olympusDAO.ProtocolMetric.staked_supply_percent = SyntheticField(
+  lambda sohm_supply, total_supply: 100 * sohm_supply / total_supply,
+  SyntheticField.FLOAT,
+  [
+    olympusDAO.ProtocolMetric.sOhmCirculatingSupply,
+    olympusDAO.ProtocolMetric.totalSupply
+  ],
+  default=100.0
+)
+
 olympusDAO.ProtocolMetric.unstaked_supply_percent = 100 - olympusDAO.ProtocolMetric.staked_supply_percent
 
-olympusDAO.ProtocolMetric.rfv_per_ohm = olympusDAO.ProtocolMetric.treasuryRiskFreeValue / (olympusDAO.ProtocolMetric.totalSupply + 1)
-olympusDAO.ProtocolMetric.price_rfv_ratio = 100 * olympusDAO.ProtocolMetric.ohmPrice / (olympusDAO.ProtocolMetric.rfv_per_ohm + 1)
+# Treasury RFV per OHM and ratio
+olympusDAO.ProtocolMetric.rfv_per_ohm = SyntheticField(
+  lambda treasury_rfv, total_supply: treasury_rfv / total_supply if treasury_rfv / total_supply > 1 else 0,
+  SyntheticField.FLOAT,
+  [
+    olympusDAO.ProtocolMetric.treasuryRiskFreeValue,
+    olympusDAO.ProtocolMetric.totalSupply
+  ]
+)
 
-olympusDAO.ProtocolMetric.tmv_per_ohm = olympusDAO.ProtocolMetric.treasuryMarketValue / (olympusDAO.ProtocolMetric.totalSupply + 1)
-olympusDAO.ProtocolMetric.price_tmv_ratio = 100 * olympusDAO.ProtocolMetric.ohmPrice / (olympusDAO.ProtocolMetric.tmv_per_ohm + 1)
+olympusDAO.ProtocolMetric.price_rfv_ratio = 100 * olympusDAO.ProtocolMetric.ohmPrice / olympusDAO.ProtocolMetric.rfv_per_ohm
+
+# Treasury market value per OHM and ratio
+olympusDAO.ProtocolMetric.tmv_per_ohm = olympusDAO.ProtocolMetric.treasuryMarketValue / olympusDAO.ProtocolMetric.totalSupply
+olympusDAO.ProtocolMetric.price_tmv_ratio = 100 * olympusDAO.ProtocolMetric.ohmPrice / olympusDAO.ProtocolMetric.tmv_per_ohm
 
 protocol_metrics_1year = olympusDAO.Query.protocolMetrics(
   orderBy=olympusDAO.ProtocolMetric.timestamp,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests
 retrying
 pycoingecko
 dash-extensions
-subgrounds
+subgrounds==0.0.3


### PR DESCRIPTION
Update Subgrounds to version 0.0.3

### **IMPORTANT**: Make sure to run re-install dependencies before running (`pipenv update subgrounds` for pipenv)

Fix treasury RFV and Mkt. value per OHM charts
![Screenshot from 2022-01-25 13-51-45](https://user-images.githubusercontent.com/3653954/151040779-6653a60b-e366-4545-9055-da9b5b46175f.png)
 